### PR TITLE
fixed some synchronization issues

### DIFF
--- a/singlebeat/beat.py
+++ b/singlebeat/beat.py
@@ -11,7 +11,8 @@ REDIS_SERVER = os.environ.get('SINGLE_BEAT_REDIS_SERVER',
                               'redis://localhost:6379')
 IDENTIFIER = os.environ.get('SINGLE_BEAT_IDENTIFIER', None)
 LOCK_TIME = int(os.environ.get('SINGLE_BEAT_LOCK_TIME', 5))
-INITIAL_LOCK_TIME = int(os.environ.get('SINGLE_BEAT_INITIAL_LOCK_TIME', LOCK_TIME * 2))
+INITIAL_LOCK_TIME = int(os.environ.get('SINGLE_BEAT_INITIAL_LOCK_TIME',
+                                       LOCK_TIME * 2))
 HEARTBEAT_INTERVAL = int(os.environ.get('SINGLE_BEAT_HEARTBEAT_INTERVAL', 1))
 HOST_IDENTIFIER = os.environ.get('SINGLE_BEAT_HOST_IDENTIFIER',
                                  socket.gethostname())


### PR DESCRIPTION
- lock was only acquired for 5 ms not for 5 seconds as intended (i guess).
- using another env variable for the initial lock time 
- removed duplicate update of the lock 
