### PR TITLE
Marked single-beat installation as zip save

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,16 @@ from setuptools import setup
 
 setup(
     name='single-beat',
-    version='0.1.4',
+    version='0.1.5',
     long_description=__doc__,
     description='ensures only one instance of your process across your servers',
     url='https://github.com/ybrs/single-beat',
     packages=['singlebeat'],
     zip_safe=True,
-    install_requires=['pyuv==0.10.11',
-        'redis==2.9.1'],
+    install_requires=[
+        'pyuv >= 0.10, < 1.0.0',
+        'redis >= 2.9.1'
+    ],
     entry_points={
         'console_scripts': [
             'single-beat = singlebeat.beat:run_process',


### PR DESCRIPTION
I don't see a reason why single-beat should be not zip_safe. 
