### PR TITLE
Distribute 0.7.3 problem

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     packages=['singlebeat'],
     zip_safe=True,
     install_requires=[
-        'pyuv >= 0.10, < 1.0.0',
+        'pyuv >= 0.10,<1.0.0',
         'redis >= 2.9.1'
     ],
     entry_points={


### PR DESCRIPTION
Updated distribute can't parse install_requires

    $ virtualenv env
    $ source env/bin/activate
    $ pip install distribute -U
    Collecting distribute
    Requirement already up-to-date: setuptools>=0.7 in /Users/s.trofimov/Work/projects/itportal/envtest/lib/python2.7/site-packages (from distribute)
    Installing collected packages: distribute
    Successfully installed distribute-0.7.3
    $ pip install single-beat
    Collecting single-beat
      Downloading single-beat-0.1.6.tar.gz
        Complete output from command python setup.py egg_info:
        error in single-beat setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Invalid requirement, parse error at "'< 1.0.0'"