### PR TITLE
Fix supervisor config example

### DIFF
--- a/example/celerybeat.conf
+++ b/example/celerybeat.conf
@@ -1,5 +1,8 @@
 [program:celerybeat]
-environment=SINGLE_BEAT_IDENTIFIER="celery-beat",SINGLE_BEAT_REDIS_SERVER="redis://localhost:6379/0"
+environment=
+    SINGLE_BEAT_IDENTIFIER="celery-beat",
+    SINGLE_BEAT_REDIS_SERVER="redis://localhost:6379/0",
+    SINGLE_BEAT_WAIT_MODE="supervised"
 command=single-beat celery beat -A example.tasks
 numprocs=1
 stdout_logfile=./logs/celerybeat.log


### PR DESCRIPTION
`SINGLE_BEAT_WAIT_MODE` defaults to `heartbeat` which will cause the process to fail when supervisor runs it.  This setting needs to be set to `supervised` in order for supervisor to work.