### PR TITLE
Implement fencing to mitigate against multiple single-beat instances in RUNNING state

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,10 @@ Unreleased
 ==========
  - Support Redis Sentinel
 
+Version 0.3.0
+==============
+ - Add fencing
+
 Version 0.2.0
 ==============
  - Moved to tornado's ioloop, pyuv was hard to install, had breaking changes etc.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ SINGLE_BEAT_REDIS_SERVER='redis://redis-host:6379/1' single-beat celery beat
     3) "_kombu.binding.celery"
     4) "SINGLE_BEAT_celery-beat"
     redis 127.0.0.1:6379> get SINGLE_BEAT_celery-beat
-    "aybarss-MacBook-Air.local:43213"
+    "0:aybarss-MacBook-Air.local:43213"
     redis 127.0.0.1:6379>
     ```
 
@@ -115,7 +115,7 @@ SINGLE_BEAT_REDIS_SERVER='redis://redis-host:6379/1' single-beat celery beat
     redis 127.0.0.1:6379> keys *
     1) "SINGLE_BEAT_celery-beat"
     redis 127.0.0.1:6379> get SINGLE_BEAT_celery-beat
-    "192.168.1.1:43597"
+    "0:192.168.1.1:43597"
     ```
 
 - SINGLE_BEAT_LOG_LEVEL (default warn)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='single-beat',
-    version='0.2.0',
+    version='0.3.0',
     long_description=__doc__,
     description='ensures only one instance of your process across your servers',
     url='https://github.com/ybrs/single-beat',

--- a/singlebeat/beat.py
+++ b/singlebeat/beat.py
@@ -86,6 +86,7 @@ class Process(object):
         signal.signal(signal.SIGTERM, self.sigterm_handler)
         signal.signal(signal.SIGINT, self.sigterm_handler)
 
+        self.fence_token = 0
         self.sprocess = None
         self.pc = None
         self.state = 'WAITING'
@@ -103,6 +104,7 @@ class Process(object):
 
     def timer_cb_waiting(self):
         if self.acquire_lock():
+            logging.info("acquired lock, spawning child process")
             return self.spawn_process()
         # couldnt acquire lock
         if config.WAIT_MODE == 'supervised':
@@ -113,10 +115,22 @@ class Process(object):
 
     def timer_cb_running(self):
         rds = config.get_redis()
-        rds.set("SINGLE_BEAT_{identifier}".format(identifier=self.identifier),
-                "{host_identifier}:{pid}".format(host_identifier=config.HOST_IDENTIFIER,
-                                                 pid=self.sprocess.pid),
+
+        # read current fencing token
+        redis_fence_token = rds.get("SINGLE_BEAT_{identifier}".format(identifier=self.identifier)).split(":")[0]
+        logging.debug("expected fence token: {} fence token read from Redis: {}".format(self.fence_token, redis_fence_token))
+
+        if self.fence_token == int(redis_fence_token):
+            self.fence_token += 1
+            rds.set("SINGLE_BEAT_{identifier}".format(identifier=self.identifier),
+                "{}:{}:{}".format(self.fence_token, config.HOST_IDENTIFIER, self.sprocess.pid),
                 ex=config.LOCK_TIME)
+        else:
+            logging.error("fence token did not match (lock is held by another process), terminating")
+            logging.debug("expected fence token: {} fence token read from Redis: {}".format(self.fence_token,
+                                                                                            redis_fence_token))
+            # send sigterm to ourself and let the sigterm_handler do the rest
+            os.kill(os.getpid(), signal.SIGTERM)
 
     def timer_cb(self):
         logger.debug("timer called %s state=%s",
@@ -127,9 +141,9 @@ class Process(object):
 
     def acquire_lock(self):
         rds = config.get_redis()
-        return rds.execute_command('SET', 'SINGLE_BEAT_%s' % self.identifier,
-                                   "%s:%s" % (config.HOST_IDENTIFIER, '0'),
-                                   'NX', 'EX', config.INITIAL_LOCK_TIME)
+        return rds.execute_command("SET", "SINGLE_BEAT_{}".format(self.identifier),
+                                   "{}:{}:{}".format(self.fence_token, config.HOST_IDENTIFIER, 0),
+                                   "NX", "EX", config.INITIAL_LOCK_TIME)
 
     def sigterm_handler(self, signum, frame):
         """ When we get term signal

--- a/singlebeat/beat.py
+++ b/singlebeat/beat.py
@@ -104,11 +104,11 @@ class Process(object):
 
     def timer_cb_waiting(self):
         if self.acquire_lock():
-            logging.info("acquired lock, spawning child process")
+            logger.info("acquired lock, spawning child process")
             return self.spawn_process()
         # couldnt acquire lock
         if config.WAIT_MODE == 'supervised':
-            logging.debug("already running, will exit after %s seconds"
+            logger.debug("already running, will exit after %s seconds"
                           % config.WAIT_BEFORE_DIE)
             time.sleep(config.WAIT_BEFORE_DIE)
             sys.exit()
@@ -118,7 +118,7 @@ class Process(object):
 
         # read current fencing token
         redis_fence_token = rds.get("SINGLE_BEAT_{identifier}".format(identifier=self.identifier)).split(":")[0]
-        logging.debug("expected fence token: {} fence token read from Redis: {}".format(self.fence_token, redis_fence_token))
+        logger.debug("expected fence token: {} fence token read from Redis: {}".format(self.fence_token, redis_fence_token))
 
         if self.fence_token == int(redis_fence_token):
             self.fence_token += 1
@@ -126,9 +126,8 @@ class Process(object):
                 "{}:{}:{}".format(self.fence_token, config.HOST_IDENTIFIER, self.sprocess.pid),
                 ex=config.LOCK_TIME)
         else:
-            logging.error("fence token did not match (lock is held by another process), terminating")
-            logging.debug("expected fence token: {} fence token read from Redis: {}".format(self.fence_token,
-                                                                                            redis_fence_token))
+            logger.error("fence token did not match (lock is held by another process), terminating")
+
             # send sigterm to ourself and let the sigterm_handler do the rest
             os.kill(os.getpid(), signal.SIGTERM)
 
@@ -156,7 +155,7 @@ class Process(object):
         :return:
         """
         assert(self.state in ('WAITING', 'RUNNING'))
-        logging.debug("our state %s", self.state)
+        logger.debug("our state %s", self.state)
         if self.state == 'WAITING':
             return self.ioloop.stop()
 


### PR DESCRIPTION
With short lock timeouts and a bit of bad luck (process doesn't get CPU time, network issues, GC, interrupts) you can end up with multiple processes running. I have been able to reproduce this a couple of times in a CPU restricted environment which could be disastrous.

This change saves a fencing token in the existing Redis key which gets incremented by one on every lock update. The value of this token is compared against the value which was last saved on every lock update, if they are not equal another process took the lock and the process shoots itself in the head.

Some considerations:
- I specifically opted to not use the hostname for this check.
- Due to SINGLE_BEAT_INITIAL_LOCK_TIME being high I ruled out a race happing on startup, it is impossible for two running instances to update the token with exactly the same value. This could be strengthened by starting from a random value instead of 0.
- It might be necessary to implement a different killing mechanism if single-beat isn't running in supervisor mode. With the current implementation, single-beat will exit when it detects that another instance took the lock. Please advise if you see this as necessary. In my opinion single-beat isn't a supervisor and there is no protection against the child process crashing.