### PR TITLE
fix(fencing): try to reacquire Redis lock when it expired #20

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+Version 0.3.2
+==============
+ - Try to reacquire Redis lock when it expired
+
 Version 0.3.1
 ==============
  - Fixes python 3 compatibility issue

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='single-beat',
-    version='0.3.1',
+    version='0.3.2',
     long_description=long_description,
     long_description_content_type="text/markdown",
     description='ensures only one instance of your process across your servers',


### PR DESCRIPTION
This PR fixes #20 

Under high load it is possible that the timer doesn't update the lock within SINGLE_BEAT_LOCK_TIME so the lock held in Redis expires. Because of this, the fence token which is stored in the lock cannot be read which leads to an unhandled exception.

This change makes single-beat attempt to reacquire the lock in case it can't be read. If unsuccessful single-beat exits, possible reasons are that Redis is unavailable or that the lock was already acquired by another single-beat process.

This can be simulated by starting a single single-beat instance and by then deleting the lock key from Redis manually with redis-cli.