### PR TITLE
Fix logging callbacks don't flush

### DIFF
--- a/singlebeat/beat.py
+++ b/singlebeat/beat.py
@@ -178,9 +178,11 @@ class Process(object):
 
     def stdout_read_cb(self, data):
         sys.stdout.write(data.decode())
+        sys.stdout.flush()
 
     def stderr_read_cb(self, data):
         sys.stderr.write(data.decode())
+        sys.stderr.flush()
 
     def timer_cb_paused(self):
         pass


### PR DESCRIPTION
If the logging callbacks don't flush, logging done by the child process doesn't appear for a long time, possibly when the buffer is full.
    
This causes any logging output of child processes to not appear until you exit the app for example, have had this discussion before, but I'm still convinced this is needed.
    
Flushing every log line of the child process is not a big deal because the child process hardly does any logging.