### PR TITLE
[BUGFIX] Adds missing comma.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     install_requires=[
         'tornado >= 6.0,<7.0',
         'redis >= 2.9.1',
-        'aioredis >= 2.0'
+        'aioredis >= 2.0',
         'Click>=7.0'
     ],
     test_require=[


### PR DESCRIPTION
I noticed `setup.py` was missing a comma for one of the requirements which would cause the last two to concatenate.