### PR TITLE
Unicodedecode patch

### DIFF
--- a/singlebeat/beat.py
+++ b/singlebeat/beat.py
@@ -194,10 +194,10 @@ class Process(object):
             self.state = State.WAITING
 
     def stdout_read_cb(self, data):
-        sys.stdout.write(data.decode())
+        sys.stdout.write(data)
 
     def stderr_read_cb(self, data):
-        sys.stderr.write(data.decode())
+        sys.stderr.write(data)
 
     async def timer_cb_paused(self):
         pass

--- a/singlebeat/beat.py
+++ b/singlebeat/beat.py
@@ -324,7 +324,7 @@ class Process(object):
 
     async def _read_stream(self, stream, cb):
         while True:
-            line = await stream.read(100)
+            line = await stream.read(-1)
             if line:
                 cb(line)
             else:

--- a/singlebeat/beat.py
+++ b/singlebeat/beat.py
@@ -324,8 +324,7 @@ class Process(object):
             await asyncio.sleep(config.HEARTBEAT_INTERVAL)
 
     async def _read_stream(self, stream, cb):
-        Utf8Decoder = codecs.getincrementaldecoder('utf-8')
-        decoder = Utf8Decoder(error='strict')
+        decoder = codecs.getincrementaldecoder('utf-8')(errors='strict')
 
         while True:
             line = await stream.read(100)

--- a/singlebeat/beat.py
+++ b/singlebeat/beat.py
@@ -1,3 +1,4 @@
+import codecs
 import functools
 import json
 import os
@@ -323,10 +324,13 @@ class Process(object):
             await asyncio.sleep(config.HEARTBEAT_INTERVAL)
 
     async def _read_stream(self, stream, cb):
+        Utf8Decoder = codecs.getincrementaldecoder('utf-8')
+        decoder = Utf8Decoder(error='strict')
+
         while True:
-            line = await stream.read(-1)
+            line = await stream.read(100)
             if line:
-                cb(line)
+                cb(decoder.decode(line))
             else:
                 break
 


### PR DESCRIPTION
We had problems with single-beat crashing when we output log messages containing utf-8 characters. Always reading 100 bytes would sometimes split a unicode character in two, resulting in UnicodeDecodeError.

This fixes that.