### PR TITLE
Fix "redis.sentinel" import error for redis sentinel model

### DIFF
--- a/singlebeat/beat.py
+++ b/singlebeat/beat.py
@@ -6,6 +6,7 @@ import sys
 import time
 import socket
 import redis
+import redis.sentinel
 import logging
 import signal
 import aioredis


### PR DESCRIPTION
Fix this following import error for sentinel model:
```
Traceback (most recent call last):
  File "/apps/venv/bin/single-beat", line 5, in <module>
    from singlebeat.beat import main
  File "/apps/venv/lib64/python3.9/site-packages/singlebeat/beat.py", line 117, in <module>
    config = Config()
  File "/apps/venv/lib64/python3.9/site-packages/singlebeat/beat.py", line 85, in __init__
    self._sentinel = redis.sentinel.Sentinel(sentinels,
AttributeError: module 'redis' has no attribute 'sentinel'
```